### PR TITLE
fixed pd.Series bug in StandardScaler class

### DIFF
--- a/regression_tools/dftransformers.py
+++ b/regression_tools/dftransformers.py
@@ -94,17 +94,25 @@ class StandardScaler(TransformerMixin):
         self._scaler = SS()
 
     def fit(self, X, *args, **kwargs):
-        if isinstance(X, pd.DataFrame) or isinstance(X, pd.Series):
+        if isinstance(X, pd.DataFrame):
             self._scaler.fit(X.values)
+        elif isinstance(X, pd.Series):
+            self._scaler.fit(X.values.reshape(-1,1))
         else:
             self._scaler.fit(X)
         return self
 
     def transform(self, X, *args, **kwargs):
-        if isinstance(X, pd.DataFrame) or isinstance(X, pd.Series):
+        if isinstance(X, pd.DataFrame):
             return pd.DataFrame(
                 self._scaler.transform(X.values),
                 columns=X.columns,
+                index=X.index)
+        elif isinstance(X, pd.Series):
+            return pd.Series(
+                #StandardScaler requires 2-d data, pd.Series requires 1-d data
+                self._scaler.transform(X.values.reshape(-1,1)).reshape(-1),
+                name=X.name,
                 index=X.index)
         else:
             return self._scaler.transform(X)

--- a/regression_tools/dftransformers.py
+++ b/regression_tools/dftransformers.py
@@ -35,9 +35,9 @@ class Identity(TransformerMixin):
 
 
 class FeatureUnion(TransformerMixin):
-    """Just like sklean.FeatureUnion, but also works for pandas.DataFrame
+    """Just like sklearn.FeatureUnion, but also works for pandas.DataFrame
     objects.
-    
+
     Parameters
     ----------
     transformer_list: list of Transformer objects.


### PR DESCRIPTION
Users should now be able to use the StandardScaler class without problems, as it appears you originally intended in the code. I didn't do much testing, but this worked:

`data = pd.Series([2,34,2,5,2,1,5,3,3], name="Cheese", index=['a','b','c','d','e','f','g','h','i'])`
`SS = dftransformers.StandardScaler()`
`SS.fit(data)`
`f = SS.transform(data)`
`f, f.name, f.index`
`>>>(a   -0.439229`
`b    2.804310`
`c   -0.439229`
`d   -0.135147`
`e   -0.439229`
`f   -0.540590`
`g   -0.135147`
`h   -0.337869`
`i   -0.337869`
`Name: Cheese, dtype: float64,`
`'Cheese',`
`Index(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'], dtype='object'))`

I won't copy and paste it all, but a pd.Series without pd.Series.name and pd.Series.index worked as well.