### PR TITLE
Add classes for better dummies encoding, flags for missing data, and missing data replacement

### DIFF
--- a/regression_tools/dftransformers.py
+++ b/regression_tools/dftransformers.py
@@ -492,9 +492,11 @@ class NanReplacer(TransformerMixin):
             return np.nanmin(arr)
         elif self.fill == 'median':
             return np.nanmedian(arr)
+        elif self.fill == "null":
+            return "_is_null"
         else:
             raise ValueError("Use one of ['zero', 'mean', 'median', "
-                             "'max', 'min']) for fill")
+                             "'max', 'min', 'null']) for fill")
 
     def _replace_nans(self, arr):
         """Returns arr with nans replaced with corresponding values in

--- a/regression_tools/dftransformers.py
+++ b/regression_tools/dftransformers.py
@@ -360,7 +360,7 @@ class MissingIndicator(TransformerMixin):
         arr = X.copy()
         if isinstance(X, pd.DataFrame):
             arr = arr.values
-        self.missing_data_cols = np.where(np.isnan(arr).any(axis=0))[0]
+        self.missing_data_cols = np.where(pd.isnull(arr).any(axis=0))[0]
         if isinstance(X, pd.DataFrame):
             self.missing_data_names = X.columns[self.missing_data_cols]
         if len(self.missing_data_cols) == 0:
@@ -375,7 +375,7 @@ class MissingIndicator(TransformerMixin):
                           "No transformations will be made. Returning X.")
             return X
         missing_array = np.zeros(X.shape, dtype=np.int8)
-        missing_array += np.isnan(X)
+        missing_array += pd.isnull(X)
         # subset columns if necessary
         if len(X.shape) == 2:
             missing_array = missing_array[:,self.missing_data_cols]
@@ -507,7 +507,7 @@ class NanReplacer(TransformerMixin):
         np.ndarray of numeric dtype
         """
         arr = arr.copy()
-        idxs = np.where(np.isnan(arr))
+        idxs = np.where(pd.isnull(arr))
         # note: two-line if condition below. indentation is confusing.
         if (isinstance(arr, pd.Series) or
             (isinstance(arr, np.ndarray) and len(arr.shape) == 1)):

--- a/regression_tools/dftransformers.py
+++ b/regression_tools/dftransformers.py
@@ -454,7 +454,7 @@ class NanReplacer(TransformerMixin):
             self.values = self._find_fill(X)
         else:
             self.values = np.apply_along_axis(
-                lambda x: self._find_fill (x), 0, X)
+                lambda x: self._find_fill(x), 0, X)
         return self
 
     def transform(self, X, *args, **kwargs):

--- a/regression_tools/dftransformers.py
+++ b/regression_tools/dftransformers.py
@@ -129,3 +129,144 @@ class Intercept(TransformerMixin):
             return pd.Series(np.ones(X.shape[0]),
                              index=X.index, name="intercept")
         return np.ones(X.shape[0])
+
+class DummiesEncoder(TransformerMixin):
+    """Makes dummy variables for all categorical columns in a dataframe.
+    """
+    def __init__(self, idxs="all", levels=None, less=None, drop=True):
+        """Instatiates transformer
+        Parameters:
+        idxs ("all" or array-like): column indicies to generate dummies
+            array-like str column names for pd.DataFrame
+            array-like int column indicies for np.array
+            or "all" for all columns regardless of data object
+            use "all" for pd.Series
+
+        levels (mapping): dict of col_index:list of str or int for levels to
+            dummify or None to encode all levels for all features
+            Example: df = pd.DataFrame({"color":"blue", "orange", "red"},
+                                        "flavor": "berry", "orange", "cherry"})
+                     sd = SmartDummies(levels={"color":["red","blue],
+                                               "flavor":["cherry", "berry"]})
+                     sd.fit(df)
+                     sd.transform(df)
+                     >>>"color_red" "color_blue" "flavor_cherry" "flavor_berry"
+                         0           1             0              1
+                         0           0             0              0
+                         1           0             1              0
+            important: explicitly defining levels overrides num_dummies below,
+            i.e. if you want explicitly set the levels with n-1 total levels,
+            make sure to do that with this option.
+        less (int > 0): for given n feature levels, n - less to encode.
+            Useful for models that require n-1 or fewer levels to avoid
+            gradient descent problems. Use None for all levels.
+
+        drop (bool): whether to drop columns that will be dummified
+        """
+        self.idxs = idxs
+        self.levels = levels
+        if less == None:
+            self.less = None
+        else:
+            self.less = -(less)
+        self.drop = drop
+    def fit(self, X):
+        """
+        """
+        # get all indices if not user-defined
+        if self.idxs == "all":
+            if isinstance(X, pd.DataFrame):
+                self.idxs = [col for col in X.columns]
+            elif isinstance(X, pd.Series):
+                self.idxs = [X.name]
+            elif isinstance(X, np.ndarray):
+                self.idxs = [i for i in range(X.shape[1])]
+            else:
+                raise TypeError("Expected pd.DataFrame, pd.Series, or np.ndarray")
+
+        # get levels if not user-defined
+        if not self.levels:
+            self.levels = {}
+            for index in self.idxs:
+                if isinstance(X, pd.DataFrame):
+                    self.levels[index] = self._get_levels(X[index])
+                elif isinstance(X, pd.Series):
+                    self.levels[index] = self._get_levels(X)
+                else:
+                    self.levels[index] = self._get_levels(X[:,index])
+        return self
+    def transform(self, X):
+        """
+        """
+
+        # handle pd.DataFrame
+        if isinstance(X, pd.DataFrame):
+            colnames = []
+            dum_arr = self._make_dum_array(X)
+            for key in self.levels:
+                colnames.extend(self._make_colnames(key, self.levels[key]))
+            dum_df = pd.DataFrame(dum_arr, columns=colnames)
+            if self.drop:
+                temp_df = X[[col for col in X.columns if col not in self.idxs]]
+                return pd.concat((temp_df, dum_df), axis=1)
+            else:
+                return pd.concat((X, dum_df), axis=1)
+        # handle pd.Series
+        elif isinstance(X, pd.Series):
+            colnames = []
+            values = np.array(self.levels[self.idxs[0]]) == X.values.reshape(-1,1)
+            if not self.drop:
+                values = np.concatenate((X.values.reshape(-1,1), values), axis=1)
+                colnames.append(X.name)
+                colnames.extend(self._make_colnames(X.name,
+                                                    self.levels[self.idxs[0]]))
+            else:
+                colnames = self._make_colnames(X.name, self.levels[self.idxs[0]])
+            return pd.DataFrame(values, columns=colnames)
+
+        # handle np.array
+        # check for correct dimensions here?
+        elif isinstance(X, np.ndarray):
+            # instantiate empty array of zeros to update with dummies
+            dum_arr = self._make_dum_array(X)
+
+            if self.drop:
+                non_dum_arr = X[:,[i for i in range(X.shape[1])
+                                   if i not in self.idxs]]
+                return np.concatenate((non_dum_arr, dum_arr), axis=1)
+            else:
+                return np.concatenate((X, dum_arr), axis=1)
+
+        else:
+            raise TypeError("Expected pd.DataFrame, pd.Series, or np.ndarray")
+
+
+    def _get_levels(self, arr):
+        """Returns unique levels in array-like arr"""
+        return list(set(arr))[:self.less]
+
+    def _make_colnames(self, prefix, levels):
+        """Returns list of str column names
+        Parameters:
+        prefix (str): prefix to appear in all column names
+        levels (list of str): list of suffixes to append to individual columns
+
+        Returns:
+        list of str in form prefix_level
+        """
+        return [f"{prefix}_{level}" for level in levels]
+
+    def _make_dum_array(self, X):
+        """Returns np.array of dummied variables"""
+        dum_col_cnt = sum(len(val_list) for val_list in self.levels.values())
+        dum_arr = np.zeros((X.shape[0], dum_col_cnt), dtype=np.int8)
+        curr_col_idx = 0
+        for key in self.levels:
+            if isinstance(X, pd.DataFrame):
+                curr_vals = np.array(X[key].values).reshape(-1,1)
+            else:
+                curr_vals = X[:,key].reshape(-1,1)
+            # broadcast boolean check to fill array
+            (dum_arr[:,curr_col_idx:curr_col_idx + len(self.levels[key])]) += (np.array(self.levels[key]) == curr_vals)
+            curr_col_idx += len(self.levels[key])
+        return dum_arr

--- a/regression_tools/dftransformers.py
+++ b/regression_tools/dftransformers.py
@@ -464,6 +464,9 @@ class NanReplacer(TransformerMixin):
             return np.nanmin(arr)
         elif self.fill == 'median':
             return np.nanmedian(arr)
+        else:
+            raise ValueError("Use one of ['zero', 'mean', 'median', "
+                             "'max', 'min']) for fill")
 
     def _replace_nans(self, arr):
         """Returns arr with nans replaced with corresponding values in

--- a/regression_tools/dftransformers.py
+++ b/regression_tools/dftransformers.py
@@ -185,7 +185,7 @@ class DummiesEncoder(TransformerMixin):
             self.less = less
         self.drop = drop
 
-    def fit(self, X):
+    def fit(self, X, *args, **kwargs):
         """Fit DummiesEncoder to X"""
         # get all indices if not user-defined
         if self.idxs == "all":
@@ -210,7 +210,7 @@ class DummiesEncoder(TransformerMixin):
                     self.levels[index] = self._get_levels(X[:,index])
         return self
 
-    def transform(self, X):
+    def transform(self, X, *args, **kwargs):
         """Transform X using the dummies encoding"""
 
         # handle pd.DataFrame
@@ -331,7 +331,7 @@ class MissingIndicator(TransformerMixin):
         self.missing_data_cols = None
         self.missing_data_names = None
 
-    def fit(self, X):
+    def fit(self, X, *args, **kwargs):
         """Fit MissingIndicator to X"""
         arr = X.copy()
         if isinstance(X, pd.DataFrame):
@@ -344,7 +344,7 @@ class MissingIndicator(TransformerMixin):
                           "No transformations will be made.")
         return self
 
-    def transform(self, X):
+    def transform(self, X, *args, **kwargs):
         """Transform X with fit MissingIndicator"""
         if len(self.missing_data_cols) == 0:
             warnings.warn("Warning: no missing data was found during fitting. "
@@ -424,7 +424,7 @@ class NanReplacer(TransformerMixin):
         self.fill = fill
         self.values = None
 
-    def fit(self, X):
+    def fit(self, X, *args, **kwargs):
         """Fit NanReplacer to X"""
         if isinstance(X, pd.Series):
             self.values = self._find_fill(X)
@@ -433,7 +433,7 @@ class NanReplacer(TransformerMixin):
                 lambda x: self._find_fill (x), 0, X)
         return self
 
-    def transform(self, X):
+    def transform(self, X, *args, **kwargs):
         """Transform X with fit NanReplacer"""
         num_array = self._replace_nans(X)
         if isinstance(X, np.ndarray):

--- a/regression_tools/dftransformers.py
+++ b/regression_tools/dftransformers.py
@@ -199,7 +199,7 @@ class DummiesEncoder(TransformerMixin):
                 raise TypeError("Expected pd.DataFrame, pd.Series, or np.ndarray")
 
         # get levels if not user-defined
-        if not self.levels:
+        if not self.user_input_levels:
             self.levels = {}
             for index in self.idxs:
                 if isinstance(X, pd.DataFrame):

--- a/regression_tools/dftransformers.py
+++ b/regression_tools/dftransformers.py
@@ -174,6 +174,10 @@ class DummiesEncoder(TransformerMixin):
     """
     def __init__(self, idxs="all", levels=None, less=None, drop=True):
         self.idxs = idxs
+        if not levels:
+            self.user_input_levels = False
+        else:
+            self.user_input_levels = True
         self.levels = levels
         if less == None:
             self.less = None

--- a/regression_tools/dftransformers.py
+++ b/regression_tools/dftransformers.py
@@ -219,7 +219,7 @@ class DummiesEncoder(TransformerMixin):
             dum_arr = self._make_dum_array(X)
             for key in self.levels:
                 colnames.extend(self._make_colnames(key, self.levels[key]))
-            dum_df = pd.DataFrame(dum_arr, columns=colnames)
+            dum_df = pd.DataFrame(dum_arr, columns=colnames, index=X.index)
             if self.drop:
                 temp_df = X[[col for col in X.columns if col not in self.idxs]]
                 return pd.concat((temp_df, dum_df), axis=1)


### PR DESCRIPTION
I have added the DummiesEncoder, MissingIndicator, and NanReplacer classes to dftransformers.py.

They seem to work well at this point and be robust to np.nan of different dtypes (which I spent yesterday tearing my hair out over). This code was a lot cleaner until I had to add lots of special nan handling. There are still some issues to work out and features to add including:

- code handlers for np.nan in custom DummiesEncoder levels dict
- deal with np.inf and any other special values
- add ability to handle custom missing data values to MissingIndicator and NanReplacer, e.g. -9
- rename NanReplacer to something more appropriate once the above bullet is completed
